### PR TITLE
Add strongbox-prefs-tool: macOS CLI for exporting and importing Strongbox preferences

### DIFF
--- a/tools/strongbox-prefs-tool/Package.swift
+++ b/tools/strongbox-prefs-tool/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "strongbox-prefs-tool",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "strongbox-prefs",
+            path: "Sources/StrongboxPrefs"
+        )
+    ]
+)

--- a/tools/strongbox-prefs-tool/README.md
+++ b/tools/strongbox-prefs-tool/README.md
@@ -1,0 +1,76 @@
+# strongbox-prefs-tool
+
+A small macOS CLI tool for **exporting and importing Strongbox preferences** — useful when setting up a new Mac or transferring your configuration to a second device.
+
+## Build
+
+```bash
+cd tools/strongbox-prefs-tool
+swift build -c release
+# Binary: .build/release/strongbox-prefs
+```
+
+Optionally copy to PATH:
+
+```bash
+cp .build/release/strongbox-prefs /usr/local/bin/strongbox-prefs
+```
+
+## Usage
+
+```
+strongbox-prefs export [output.json]          Export settings to JSON
+strongbox-prefs import <input.json>           Import settings from JSON (replace mode)
+strongbox-prefs import <input.json> --merge   Import settings, keep existing values
+strongbox-prefs list                          Show current exportable settings
+```
+
+### Import modes
+
+**Replace (default):** All exportable keys are removed from both plist files first, giving a clean baseline. Only the values present in the import file are then written. This guarantees no stale settings survive from a previous configuration.
+
+**`--merge`:** Existing settings are left untouched; only keys present in the import file are overwritten. Useful when combining settings from two sources or transferring a partial set.
+
+In both modes a timestamped backup is written to the current directory before any changes are made:
+
+```
+strongbox-prefs-backup-2026-03-24T15-34-02.json
+```
+
+### Typical workflow
+
+#### On the old Mac
+
+```bash
+strongbox-prefs export strongbox-settings.json
+# Transfer strongbox-settings.json to the new Mac (AirDrop, iCloud, …)
+```
+
+#### On the new Mac
+
+```bash
+# Launch Strongbox once (so the Group Container is created), then:
+strongbox-prefs import strongbox-settings.json
+# Restart Strongbox to apply all changes
+```
+
+## What is exported?
+
+Only **user-configurable, non-sensitive settings** are included (~87 keys), e.g.:
+
+- Auto-lock timeouts, App Lock mode and delay
+- Clipboard handling (clear timeout, handoff, conceal from monitors)
+- Backup and sync options (rolling backups, atomic SFTP writes, Wi-Fi Sync)
+- UI preferences (markdown notes, colorblind palette, window behaviour)
+- TOTP display (separator, hide countdown, add OTPAuth URL)
+- Password generator and FavIcon download configuration
+- SSH Agent, browser AutoFill proxy
+- Keyboard shortcuts (global hotkeys via MASShortcutBinder)
+
+**Not included** (security-sensitive or device-specific):
+
+- License / Pro status
+- Biometric cache, App Lock PIN
+- CloudKit tokens / zone state
+- Database list and metadata
+- Install date, launch counters

--- a/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
+++ b/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
@@ -1,4 +1,19 @@
 // strongbox-prefs – Export / Import Strongbox macOS Preferences
+//
+// Strongbox writes user settings to TWO separate plist files:
+//
+//   1. App Group plist  (most settings – via Settings.sharedInstance)
+//      ~/Library/Group Containers/<groupID>/Library/Preferences/<groupID>.plist
+//      groupID = "group.strongbox.mac.mcguill"  (dev / direct distribution)
+//              = "4326J8XDF2.group.strongbox.mac.mcguill"  (App Store build)
+//
+//   2. Standard defaults plist  (keyboard shortcuts – via MASShortcutBinder)
+//      ~/Library/Containers/com.markmcguill.strongbox/Data/Library/Preferences/
+//          com.markmcguill.strongbox.plist
+//
+// This tool reads / writes both files so that ALL user-configurable settings
+// are captured in a single export JSON.
+//
 // Usage:
 //   strongbox-prefs export [output.json]
 //   strongbox-prefs import <input.json>
@@ -6,38 +21,63 @@
 
 import Foundation
 
-// MARK: – Known Plist Locations
+// MARK: – Plist Sources
 
-/// Strongbox macOS stores its shared settings in the App Group container.
-/// Two known group names exist (dev vs. App-Store build).
+/// Represents one preferences storage location together with its exportable key whitelist.
+struct PlistSource {
+    let label: String
+    let url: URL
+    let exportableKeys: Set<String>
+}
+
+// ---------------------------------------------------------------------------
+// Source 1 – App Group defaults
+// ---------------------------------------------------------------------------
+
+/// Two known App Group IDs (dev build vs. App Store build).
 let knownGroupIDs = [
     "group.strongbox.mac.mcguill",
     "4326J8XDF2.group.strongbox.mac.mcguill",
 ]
 
-func plistURL(for groupID: String) -> URL {
-    let gc = FileManager.default.homeDirectoryForCurrentUser
-        .appending(path: "Library/Group Containers/\(groupID)/Library/Preferences/\(groupID).plist",
-                   directoryHint: .notDirectory)
-    return gc
+func appGroupPlistURL(for groupID: String) -> URL {
+    FileManager.default.homeDirectoryForCurrentUser
+        .appending(
+            path: "Library/Group Containers/\(groupID)/Library/Preferences/\(groupID).plist",
+            directoryHint: .notDirectory
+        )
 }
 
-func locatePlist() -> (url: URL, groupID: String)? {
-    for id in knownGroupIDs {
-        let url = plistURL(for: id)
-        if FileManager.default.fileExists(atPath: url.path) {
-            return (url, id)
-        }
-    }
-    return nil
-}
-
-// MARK: – Exportable Keys
-
-/// Only user-facing settings are exported.
-/// Internal state (license, biometrics cache, launch counts, CloudKit tokens, …) is excluded.
-let exportableKeys: Set<String> = [
-    // UI / Behaviour
+/// Keys exported from the App Group plist.
+/// Derived by reading every `static NSString* const k…` in Settings.m and
+/// keeping only those that back user-facing preferences.
+///
+/// Excluded intentionally:
+///   • fullVersion / endFreeTrialDate            – license state
+///   • lastEntitlementCheckAttempt / …           – entitlement housekeeping
+///   • appHasBeenDowngraded… / hasPrompted…       – one-time prompt flags
+///   • hasShownFirstRunWelcome / freeTrialNudge…  – onboarding state
+///   • installDate / launchCountKey               – telemetry
+///   • hasAskedAboutDatabaseOpenInBackground      – one-time prompt flag
+///   • hasPromptedForThirdPartyAutoFill           – one-time prompt flag
+///   • lastKnownGoodDatabaseState / autoFill…     – biometric cache (security)
+///   • cloudKitZoneCreated / changeNotifications… – CloudKit internal state
+///   • hasWarnedAboutCloudKitUnavailability        – one-time warning flag
+///   • lastCloudKitRefresh                        – sync timestamp
+///   • wiFiSyncPasscodeSSKey                      – stored in SecretStore, not plist
+///   • wiFiSyncPasscodeSSKeyHasBeenInitialized    – internal init flag
+///   • wiFiSyncServiceName                        – device-specific
+///   • lastWiFiSyncPasscodeError                  – transient error string
+///   • autoFillWroteCleanly                       – crash-guard flag
+///   • lastQuickTypeMultiDbRegularClear            – internal cleanup timestamp
+///   • failedUnlockAttempts                       – security counter
+///   • appLockPin2.0                              – stored in SecretStore, not plist
+///   • duressDummyData                            – security data (setter is NOTIMPL)
+///   • passwordStrengthConfig                     – getter returns .defaults, setter is NOTIMPL
+///   • useUSGovAuthority                          – getter returns NO, setter is NOP
+///   • checkPinYin                                – always returns NO on macOS
+let appGroupExportableKeys: Set<String> = [
+    // ── UI / Window behaviour ──────────────────────────────────────────────
     "alwaysShowPassword",
     "autoSave",
     "clearClipboardEnabled",
@@ -48,53 +88,76 @@ let exportableKeys: Set<String> = [
     "colorizeUseColorBlindPalette",
     "concealClipboardFromMonitors-DefaultON-27-Dec-2022",
     "disableCustomViews",
+    "floatOnTop",
     "hideOnCopy",
+    "largeTextViewFloatOnTop",
     "lockDatabaseOnWindowClose",
     "lockDatabasesOnScreenLock",
     "lockEvenIfEditing",
     "markdownNotes",
     "miniaturizeOnCopy",
+    "passwordGeneratorFloatOnTop",
     "quickRevealWithOptionKey",
-    "quitTerminatesProcessEvenInSystemTrayMode",
     "quitOnAllWindowsClosed",
+    "quitTerminatesProcessEvenInSystemTrayMode",
     "screenCaptureBlocked",
+    "showAutoFillTotpCopiedMessage",
     "showCopyFieldButton",
-    "showDatabasesManagerOnCloseAllWindows",
     "showDatabasesManagerOnAppLaunch",
+    "showDatabasesManagerOnCloseAllWindows",
+    "showHiddenDatabases",
     "showOfflineOptionsOnLocalDeviceDatabases",
+    "showPasswordGenInTray",
     "showPasswordImmediatelyInOutline",
     "showSystemTrayIcon",
-    "showPasswordGenInTray",
-    "showAutoFillTotpCopiedMessage",
     "hideDockIconOnAllMinimized",
     "closeManagerOnLaunch",
     "autoLaunchSingleDatabase",
     "autoCommitScannedTotp",
+    "systemMenuClickAction",
 
-    // Auto-Lock
+    // ── Appearance ────────────────────────────────────────────────────────
+    "appAppearance2",
+
+    // ── Auto-Lock ─────────────────────────────────────────────────────────
     "autoLockTimeout",
     "autoLockIfInBackgroundTimeoutSeconds",
     "autoPromptForTouchIdOnActivate",
 
-    // Key Files
+    // ── App Lock ──────────────────────────────────────────────────────────
+    "appLockMode2.0",
+    "appLockDelay2.0",
+    "appLockAppliesToPreferences",
+    "deleteDataAfterFailedUnlockCount",
+
+    // ── Access / Restrictions ─────────────────────────────────────────────
+    "databasesAreAlwaysReadOnly",
+    "disableExport",
+    "disablePrinting",
+    "disableCopyTo",
+    "disableMakeVisibleInFiles",
+
+    // ── Key Files ─────────────────────────────────────────────────────────
     "hideKeyFileNameOnLockScreen",
     "doNotRememberKeyFile",
 
-    // Password / TOTP
+    // ── Password Generation / TOTP ────────────────────────────────────────
     "passwordGenerationConfig",
     "trayPasswordGenerationConfig",
     "addLegacySupplementaryTotpCustomFields",
     "addOtpAuthUrl",
     "twoFactorEasyReadSeparator",
-    "twoFactorHideCountdownDigits",   // NOTE: macOS uses this key; iOS uses "twoFactorHideCountdownDigits2"
+    // NOTE: macOS Settings.m uses "twoFactorHideCountdownDigits" (no suffix).
+    //       The iOS AppPreferences.m uses "twoFactorHideCountdownDigits2".
+    "twoFactorHideCountdownDigits",
 
-    // FavIcons / AutoFill
+    // ── FavIcons / AutoFill ───────────────────────────────────────────────
     "favIconDownloadOptions",
     "autoFillNewRecordSettings",
     "allowEmptyOrNoPasswordEntry",
     "associatedWebsites",
 
-    // Sync / Backup
+    // ── Sync / Backup ─────────────────────────────────────────────────────
     "atomicSftpWrite",
     "makeLocalRollingBackups",
     "stripUnusedHistoricalIcons",
@@ -104,40 +167,83 @@ let exportableKeys: Set<String> = [
     "disableNativeNetworkStorageOptions",
     "disableWiFiSyncClientMode",
     "wiFiSyncOn",
+    "runBrowserAutoFillProxyServer-Prod-22-Oct-2022",
+
+    // ── SSH Agent ─────────────────────────────────────────────────────────
     "runSshAgent",
     "sshAgentApprovalDefaultExpiryMinutes",
     "sshAgentRequestDatabaseUnlockAllowed",
     "sshAgentPreventRapidRepeatedUnlockRequests",
-    "runBrowserAutoFillProxyServer-Prod-22-Oct-2022",
 
-    // App Lock / Access Control
-    "appLockMode2.0",
-    "appLockDelay2.0",
-    "appLockAppliesToPreferences",
-    "deleteDataAfterFailedUnlockCount",
-    "databasesAreAlwaysReadOnly",
-    "disableExport",
-    "disablePrinting",
-    "disableCopyTo",
-    "disableMakeVisibleInFiles",
-
-    // Duplicate / Export
+    // ── Duplicate / Export behaviour ──────────────────────────────────────
     "duplicateItemPreserveTimestamp",
     "duplicateItemReferencePassword",
     "duplicateItemReferenceUsername",
     "duplicateItemEditAfterwards",
 
-    // Appearance
-    "appAppearance2",
-    "floatOnTop",
-    "passwordGeneratorFloatOnTop",
-    "largeTextViewFloatOnTop",
-    "systemMenuClickAction",
-    "showHiddenDatabases",
-
-    // Enterprise / Organisation
+    // ── Enterprise / Organisation ─────────────────────────────────────────
     "businessOrganisationName",
 ]
+
+// ---------------------------------------------------------------------------
+// Source 2 – Standard (sandboxed-app) defaults
+// ---------------------------------------------------------------------------
+
+/// The bundle identifier used by the Strongbox macOS app.
+/// The standard defaults plist lives inside the app's sandbox container.
+let knownBundleIDs = [
+    "com.markmcguill.strongbox",
+]
+
+func standardPlistURL(for bundleID: String) -> URL {
+    FileManager.default.homeDirectoryForCurrentUser
+        .appending(
+            path: "Library/Containers/\(bundleID)/Data/Library/Preferences/\(bundleID).plist",
+            directoryHint: .notDirectory
+        )
+}
+
+/// Keys exported from the standard (sandboxed-app) defaults plist.
+///
+/// MASShortcutBinder persists keyboard shortcuts via [NSUserDefaults standardUserDefaults],
+/// which maps to the app's own container plist – NOT the shared App Group plist.
+/// Key values come from Constants.m:
+///   kPreferenceGlobalShowShortcutNotification = "GlobalShowStrongboxHotKey-New"
+///   kPreferenceLaunchQuickSearchShortcut      = "LaunchQuickSearchShortcut"
+///   kPreferencePasswordGeneratorShortcut      = "PasswordGeneratorShortcut"
+let standardExportableKeys: Set<String> = [
+    "GlobalShowStrongboxHotKey-New",
+    "LaunchQuickSearchShortcut",
+    "PasswordGeneratorShortcut",
+]
+
+// ---------------------------------------------------------------------------
+// Source resolution
+// ---------------------------------------------------------------------------
+
+func resolveSources() -> [PlistSource] {
+    var sources: [PlistSource] = []
+
+    // App Group plist
+    for id in knownGroupIDs {
+        let url = appGroupPlistURL(for: id)
+        if FileManager.default.fileExists(atPath: url.path) {
+            sources.append(PlistSource(label: id, url: url, exportableKeys: appGroupExportableKeys))
+            break
+        }
+    }
+
+    // Standard plist
+    for bid in knownBundleIDs {
+        let url = standardPlistURL(for: bid)
+        if FileManager.default.fileExists(atPath: url.path) {
+            sources.append(PlistSource(label: bid, url: url, exportableKeys: standardExportableKeys))
+            break
+        }
+    }
+
+    return sources
+}
 
 // MARK: – Plist Helpers
 
@@ -156,8 +262,8 @@ func writePlist(_ dict: [String: Any], to url: URL) throws {
 
 // MARK: – JSON Helpers
 
-/// PropertyList values that JSON can't represent natively (Data, Date) are
-/// base64-encoded / ISO-8601-stringified so the JSON round-trip is lossless.
+/// PropertyList values that JSON cannot represent natively (Data, Date) are
+/// wrapped in a typed object so the round-trip is lossless.
 func plistValueToJSON(_ value: Any) -> Any {
     switch value {
     case let d as Data:
@@ -178,14 +284,9 @@ func jsonValueToPlist(_ value: Any) -> Any {
         if let type = dict["__type"] as? String {
             switch type {
             case "data":
-                if let b64 = dict["value"] as? String, let data = Data(base64Encoded: b64) {
-                    return data
-                }
+                if let b64 = dict["value"] as? String, let data = Data(base64Encoded: b64) { return data }
             case "date":
-                if let s = dict["value"] as? String,
-                   let date = ISO8601DateFormatter().date(from: s) {
-                    return date
-                }
+                if let s = dict["value"] as? String, let date = ISO8601DateFormatter().date(from: s) { return date }
             default: break
             }
         }
@@ -199,23 +300,25 @@ func jsonValueToPlist(_ value: Any) -> Any {
 // MARK: – Commands
 
 func exportPrefs(to outputPath: String?) throws {
-    guard let (plistURL, groupID) = locatePlist() else {
-        throw StrongboxPrefsError.plistNotFound
-    }
-
-    let all = try readPlist(from: plistURL)
+    let sources = resolveSources()
+    guard !sources.isEmpty else { throw StrongboxPrefsError.plistNotFound }
 
     var exported: [String: Any] = [:]
-    for key in exportableKeys {
-        if let value = all[key] {
-            exported[key] = plistValueToJSON(value)
+    var sourceLabels: [String] = []
+
+    for source in sources {
+        let all = try readPlist(from: source.url)
+        var count = 0
+        for key in source.exportableKeys {
+            if let value = all[key] {
+                exported[key] = plistValueToJSON(value)
+                count += 1
+            }
         }
+        sourceLabels.append("\(source.label) (\(count) keys)")
     }
 
-    let json = try JSONSerialization.data(
-        withJSONObject: exported,
-        options: [.prettyPrinted, .sortedKeys]
-    )
+    let json = try JSONSerialization.data(withJSONObject: exported, options: [.prettyPrinted, .sortedKeys])
 
     let destination: URL
     if let path = outputPath {
@@ -227,70 +330,82 @@ func exportPrefs(to outputPath: String?) throws {
     }
 
     try json.write(to: destination, options: .atomic)
-    print("✅ Exported \(exported.count) settings from group '\(groupID)'")
+    print("✅ Exported \(exported.count) settings total")
+    for label in sourceLabels { print("   • \(label)") }
     print("   → \(destination.path)")
 }
 
 func importPrefs(from inputPath: String) throws {
-    guard let (plistURL, groupID) = locatePlist() else {
-        throw StrongboxPrefsError.plistNotFound
-    }
+    let sources = resolveSources()
+    guard !sources.isEmpty else { throw StrongboxPrefsError.plistNotFound }
 
     let jsonData = try Data(contentsOf: URL(fileURLWithPath: inputPath))
     guard let jsonDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
         throw StrongboxPrefsError.invalidJSON
     }
 
-    var current = try readPlist(from: plistURL)
+    // Build a reverse-lookup: key → source
+    var keyToSource: [String: PlistSource] = [:]
+    for source in sources {
+        for key in source.exportableKeys {
+            keyToSource[key] = source
+        }
+    }
 
+    // Group the incoming key/value pairs by their target plist
+    var plistUpdates: [URL: [String: Any]] = [:]
     var importedCount = 0
     var skippedCount = 0
 
     for (key, jsonValue) in jsonDict {
-        guard exportableKeys.contains(key) else {
+        guard let source = keyToSource[key] else {
             print("⚠️  Skipping unknown/non-exportable key: \(key)")
             skippedCount += 1
             continue
         }
-        current[key] = jsonValueToPlist(jsonValue)
+        if plistUpdates[source.url] == nil {
+            plistUpdates[source.url] = try readPlist(from: source.url)
+        }
+        plistUpdates[source.url]![key] = jsonValueToPlist(jsonValue)
         importedCount += 1
     }
 
-    try writePlist(current, to: plistURL)
-
-    // Also sync via defaults(1) so cfprefsd picks up the changes immediately
-    let task = Process()
-    task.launchPath = "/usr/bin/defaults"
-    task.arguments = ["read", groupID]
-    task.standardOutput = FileHandle.nullDevice
-    task.standardError = FileHandle.nullDevice
-    try? task.run()
-    task.waitUntilExit()
-
-    print("✅ Imported \(importedCount) settings into group '\(groupID)'")
-    if skippedCount > 0 {
-        print("   ⚠️  Skipped \(skippedCount) unrecognised keys.")
+    // Write each modified plist back
+    for (url, dict) in plistUpdates {
+        try writePlist(dict, to: url)
     }
+
+    // Touch each source domain so cfprefsd picks up the changes immediately
+    for source in sources {
+        let task = Process()
+        task.launchPath = "/usr/bin/defaults"
+        task.arguments = ["read", source.label]
+        task.standardOutput = FileHandle.nullDevice
+        task.standardError = FileHandle.nullDevice
+        try? task.run()
+        task.waitUntilExit()
+    }
+
+    print("✅ Imported \(importedCount) settings")
+    if skippedCount > 0 { print("   ⚠️  Skipped \(skippedCount) unrecognised keys.") }
     print("   Restart Strongbox to apply all changes.")
 }
 
 func listPrefs() throws {
-    guard let (plistURL, groupID) = locatePlist() else {
-        throw StrongboxPrefsError.plistNotFound
-    }
+    let sources = resolveSources()
+    guard !sources.isEmpty else { throw StrongboxPrefsError.plistNotFound }
 
-    let all = try readPlist(from: plistURL)
-
-    print("Strongbox macOS Preferences  [\(groupID)]")
-    print(String(repeating: "─", count: 60))
-
-    let sorted = exportableKeys.sorted()
-    for key in sorted {
-        if let value = all[key] {
-            print("  \(key) = \(value)")
+    for source in sources {
+        let all = try readPlist(from: source.url)
+        print("\nStrongbox Preferences  [\(source.label)]")
+        print(String(repeating: "─", count: 60))
+        for key in source.exportableKeys.sorted() {
+            if let value = all[key] {
+                print("  \(key) = \(value)")
+            }
         }
+        print(String(repeating: "─", count: 60))
     }
-    print(String(repeating: "─", count: 60))
 }
 
 // MARK: – Errors
@@ -301,18 +416,23 @@ enum StrongboxPrefsError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .plistNotFound:
+            let groupPaths = knownGroupIDs.map {
+                "  ~/Library/Group Containers/\($0)/Library/Preferences/\($0).plist"
+            }.joined(separator: "\n")
+            let stdPaths = knownBundleIDs.map {
+                "  ~/Library/Containers/\($0)/Data/Library/Preferences/\($0).plist"
+            }.joined(separator: "\n")
             return """
-            Could not find the Strongbox preferences plist.
-            Searched in:
-            \(knownGroupIDs.map { "  ~/Library/Group Containers/\($0)/Library/Preferences/\($0).plist" }.joined(separator: "\n"))
-            Make sure Strongbox has been run at least once.
+            Could not find any Strongbox preferences plist.
+            Searched (App Group):
+            \(groupPaths)
+            Searched (Standard):
+            \(stdPaths)
+            Make sure Strongbox has been launched at least once.
             """
-        case .invalidPlist:
-            return "The plist file could not be parsed."
-        case .invalidJSON:
-            return "The input file is not valid JSON."
-        case .missingArgument(let msg):
-            return msg
+        case .invalidPlist:   return "The plist file could not be parsed."
+        case .invalidJSON:    return "The input file is not valid JSON."
+        case .missingArgument(let msg): return msg
         }
     }
 }
@@ -324,16 +444,18 @@ func printUsage() {
     strongbox-prefs – Export / Import Strongbox macOS Preferences
 
     USAGE:
-      strongbox-prefs export [output.json]   Export user settings to JSON
+      strongbox-prefs export [output.json]   Export all user settings to JSON
       strongbox-prefs import <input.json>    Import user settings from JSON
       strongbox-prefs list                   Show current exportable settings
 
     NOTES:
-      • Only user-configurable settings are included (no license data,
-        no biometric cache, no CloudKit tokens, no database list).
+      • Settings from both the App Group plist and the standard sandboxed-app
+        plist (keyboard shortcuts) are captured in a single JSON file.
+      • Only user-configurable settings are included: no license data,
+        no biometric cache, no CloudKit tokens, no database list.
       • After importing, restart Strongbox for all settings to take effect.
-      • Binary plist values (Data, Date) are preserved through a typed JSON
-        wrapper so the round-trip is lossless.
+      • Binary plist values (Data, Date) are round-tripped losslessly via a
+        typed JSON wrapper ({ "__type": "data"|"date", "value": "…" }).
     """)
 }
 
@@ -352,9 +474,7 @@ do {
         try listPrefs()
     default:
         printUsage()
-        if args.first != nil && args.first != "--help" && args.first != "-h" {
-            exit(1)
-        }
+        if args.first != nil && args.first != "--help" && args.first != "-h" { exit(1) }
     }
 } catch {
     fputs("🔴 Error: \(error.localizedDescription)\n", stderr)

--- a/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
+++ b/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
@@ -60,6 +60,7 @@ let exportableKeys: Set<String> = [
     "screenCaptureBlocked",
     "showCopyFieldButton",
     "showDatabasesManagerOnCloseAllWindows",
+    "showDatabasesManagerOnAppLaunch",
     "showOfflineOptionsOnLocalDeviceDatabases",
     "showPasswordImmediatelyInOutline",
     "showSystemTrayIcon",
@@ -68,6 +69,7 @@ let exportableKeys: Set<String> = [
     "hideDockIconOnAllMinimized",
     "closeManagerOnLaunch",
     "autoLaunchSingleDatabase",
+    "autoCommitScannedTotp",
 
     // Auto-Lock
     "autoLockTimeout",
@@ -84,7 +86,7 @@ let exportableKeys: Set<String> = [
     "addLegacySupplementaryTotpCustomFields",
     "addOtpAuthUrl",
     "twoFactorEasyReadSeparator",
-    "twoFactorHideCountdownDigits2",
+    "twoFactorHideCountdownDigits",   // NOTE: macOS uses this key; iOS uses "twoFactorHideCountdownDigits2"
 
     // FavIcons / AutoFill
     "favIconDownloadOptions",
@@ -104,14 +106,20 @@ let exportableKeys: Set<String> = [
     "wiFiSyncOn",
     "runSshAgent",
     "sshAgentApprovalDefaultExpiryMinutes",
+    "sshAgentRequestDatabaseUnlockAllowed",
+    "sshAgentPreventRapidRepeatedUnlockRequests",
     "runBrowserAutoFillProxyServer-Prod-22-Oct-2022",
 
-    // App Lock
+    // App Lock / Access Control
     "appLockMode2.0",
     "appLockDelay2.0",
     "appLockAppliesToPreferences",
     "deleteDataAfterFailedUnlockCount",
     "databasesAreAlwaysReadOnly",
+    "disableExport",
+    "disablePrinting",
+    "disableCopyTo",
+    "disableMakeVisibleInFiles",
 
     // Duplicate / Export
     "duplicateItemPreserveTimestamp",
@@ -126,6 +134,9 @@ let exportableKeys: Set<String> = [
     "largeTextViewFloatOnTop",
     "systemMenuClickAction",
     "showHiddenDatabases",
+
+    // Enterprise / Organisation
+    "businessOrganisationName",
 ]
 
 // MARK: – Plist Helpers

--- a/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
+++ b/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
@@ -1,0 +1,351 @@
+// strongbox-prefs – Export / Import Strongbox macOS Preferences
+// Usage:
+//   strongbox-prefs export [output.json]
+//   strongbox-prefs import <input.json>
+//   strongbox-prefs list
+
+import Foundation
+
+// MARK: – Known Plist Locations
+
+/// Strongbox macOS stores its shared settings in the App Group container.
+/// Two known group names exist (dev vs. App-Store build).
+let knownGroupIDs = [
+    "group.strongbox.mac.mcguill",
+    "4326J8XDF2.group.strongbox.mac.mcguill",
+]
+
+func plistURL(for groupID: String) -> URL {
+    let gc = FileManager.default.homeDirectoryForCurrentUser
+        .appending(path: "Library/Group Containers/\(groupID)/Library/Preferences/\(groupID).plist",
+                   directoryHint: .notDirectory)
+    return gc
+}
+
+func locatePlist() -> (url: URL, groupID: String)? {
+    for id in knownGroupIDs {
+        let url = plistURL(for: id)
+        if FileManager.default.fileExists(atPath: url.path) {
+            return (url, id)
+        }
+    }
+    return nil
+}
+
+// MARK: – Exportable Keys
+
+/// Only user-facing settings are exported.
+/// Internal state (license, biometrics cache, launch counts, CloudKit tokens, …) is excluded.
+let exportableKeys: Set<String> = [
+    // UI / Behaviour
+    "alwaysShowPassword",
+    "autoSave",
+    "clearClipboardEnabled",
+    "clearClipboardAfterSeconds",
+    "clipboardHandoff",
+    "clearQuickSearchOnOpen",
+    "colorizePasswords",
+    "colorizeUseColorBlindPalette",
+    "concealClipboardFromMonitors-DefaultON-27-Dec-2022",
+    "disableCustomViews",
+    "hideOnCopy",
+    "lockDatabaseOnWindowClose",
+    "lockDatabasesOnScreenLock",
+    "lockEvenIfEditing",
+    "markdownNotes",
+    "miniaturizeOnCopy",
+    "quickRevealWithOptionKey",
+    "quitTerminatesProcessEvenInSystemTrayMode",
+    "quitOnAllWindowsClosed",
+    "screenCaptureBlocked",
+    "showCopyFieldButton",
+    "showDatabasesManagerOnCloseAllWindows",
+    "showOfflineOptionsOnLocalDeviceDatabases",
+    "showPasswordImmediatelyInOutline",
+    "showSystemTrayIcon",
+    "showPasswordGenInTray",
+    "showAutoFillTotpCopiedMessage",
+    "hideDockIconOnAllMinimized",
+    "closeManagerOnLaunch",
+    "autoLaunchSingleDatabase",
+
+    // Auto-Lock
+    "autoLockTimeout",
+    "autoLockIfInBackgroundTimeoutSeconds",
+    "autoPromptForTouchIdOnActivate",
+
+    // Key Files
+    "hideKeyFileNameOnLockScreen",
+    "doNotRememberKeyFile",
+
+    // Password / TOTP
+    "passwordGenerationConfig",
+    "trayPasswordGenerationConfig",
+    "addLegacySupplementaryTotpCustomFields",
+    "addOtpAuthUrl",
+    "twoFactorEasyReadSeparator",
+    "twoFactorHideCountdownDigits2",
+
+    // FavIcons / AutoFill
+    "favIconDownloadOptions",
+    "autoFillNewRecordSettings",
+    "allowEmptyOrNoPasswordEntry",
+    "associatedWebsites",
+
+    // Sync / Backup
+    "atomicSftpWrite",
+    "makeLocalRollingBackups",
+    "stripUnusedHistoricalIcons",
+    "stripUnusedIconsOnSave",
+    "useIsolatedDropbox",
+    "useParentGroupIconOnCreate",
+    "disableNativeNetworkStorageOptions",
+    "disableWiFiSyncClientMode",
+    "wiFiSyncOn",
+    "runSshAgent",
+    "sshAgentApprovalDefaultExpiryMinutes",
+    "runBrowserAutoFillProxyServer-Prod-22-Oct-2022",
+
+    // App Lock
+    "appLockMode2.0",
+    "appLockDelay2.0",
+    "appLockAppliesToPreferences",
+    "deleteDataAfterFailedUnlockCount",
+    "databasesAreAlwaysReadOnly",
+
+    // Duplicate / Export
+    "duplicateItemPreserveTimestamp",
+    "duplicateItemReferencePassword",
+    "duplicateItemReferenceUsername",
+    "duplicateItemEditAfterwards",
+
+    // Appearance
+    "appAppearance2",
+    "floatOnTop",
+    "passwordGeneratorFloatOnTop",
+    "largeTextViewFloatOnTop",
+    "systemMenuClickAction",
+    "showHiddenDatabases",
+]
+
+// MARK: – Plist Helpers
+
+func readPlist(from url: URL) throws -> [String: Any] {
+    let data = try Data(contentsOf: url)
+    guard let dict = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+        throw StrongboxPrefsError.invalidPlist
+    }
+    return dict
+}
+
+func writePlist(_ dict: [String: Any], to url: URL) throws {
+    let data = try PropertyListSerialization.data(fromPropertyList: dict, format: .xml, options: 0)
+    try data.write(to: url, options: .atomic)
+}
+
+// MARK: – JSON Helpers
+
+/// PropertyList values that JSON can't represent natively (Data, Date) are
+/// base64-encoded / ISO-8601-stringified so the JSON round-trip is lossless.
+func plistValueToJSON(_ value: Any) -> Any {
+    switch value {
+    case let d as Data:
+        return ["__type": "data", "value": d.base64EncodedString()]
+    case let date as Date:
+        return ["__type": "date", "value": ISO8601DateFormatter().string(from: date)]
+    case let dict as [String: Any]:
+        return dict.mapValues { plistValueToJSON($0) }
+    case let arr as [Any]:
+        return arr.map { plistValueToJSON($0) }
+    default:
+        return value
+    }
+}
+
+func jsonValueToPlist(_ value: Any) -> Any {
+    if let dict = value as? [String: Any] {
+        if let type = dict["__type"] as? String {
+            switch type {
+            case "data":
+                if let b64 = dict["value"] as? String, let data = Data(base64Encoded: b64) {
+                    return data
+                }
+            case "date":
+                if let s = dict["value"] as? String,
+                   let date = ISO8601DateFormatter().date(from: s) {
+                    return date
+                }
+            default: break
+            }
+        }
+        return dict.mapValues { jsonValueToPlist($0) }
+    } else if let arr = value as? [Any] {
+        return arr.map { jsonValueToPlist($0) }
+    }
+    return value
+}
+
+// MARK: – Commands
+
+func exportPrefs(to outputPath: String?) throws {
+    guard let (plistURL, groupID) = locatePlist() else {
+        throw StrongboxPrefsError.plistNotFound
+    }
+
+    let all = try readPlist(from: plistURL)
+
+    var exported: [String: Any] = [:]
+    for key in exportableKeys {
+        if let value = all[key] {
+            exported[key] = plistValueToJSON(value)
+        }
+    }
+
+    let json = try JSONSerialization.data(
+        withJSONObject: exported,
+        options: [.prettyPrinted, .sortedKeys]
+    )
+
+    let destination: URL
+    if let path = outputPath {
+        destination = URL(fileURLWithPath: path)
+    } else {
+        let name = "strongbox-prefs-\(ISO8601DateFormatter().string(from: Date()).prefix(10)).json"
+        destination = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appending(path: name, directoryHint: .notDirectory)
+    }
+
+    try json.write(to: destination, options: .atomic)
+    print("✅ Exported \(exported.count) settings from group '\(groupID)'")
+    print("   → \(destination.path)")
+}
+
+func importPrefs(from inputPath: String) throws {
+    guard let (plistURL, groupID) = locatePlist() else {
+        throw StrongboxPrefsError.plistNotFound
+    }
+
+    let jsonData = try Data(contentsOf: URL(fileURLWithPath: inputPath))
+    guard let jsonDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+        throw StrongboxPrefsError.invalidJSON
+    }
+
+    var current = try readPlist(from: plistURL)
+
+    var importedCount = 0
+    var skippedCount = 0
+
+    for (key, jsonValue) in jsonDict {
+        guard exportableKeys.contains(key) else {
+            print("⚠️  Skipping unknown/non-exportable key: \(key)")
+            skippedCount += 1
+            continue
+        }
+        current[key] = jsonValueToPlist(jsonValue)
+        importedCount += 1
+    }
+
+    try writePlist(current, to: plistURL)
+
+    // Also sync via defaults(1) so cfprefsd picks up the changes immediately
+    let task = Process()
+    task.launchPath = "/usr/bin/defaults"
+    task.arguments = ["read", groupID]
+    task.standardOutput = FileHandle.nullDevice
+    task.standardError = FileHandle.nullDevice
+    try? task.run()
+    task.waitUntilExit()
+
+    print("✅ Imported \(importedCount) settings into group '\(groupID)'")
+    if skippedCount > 0 {
+        print("   ⚠️  Skipped \(skippedCount) unrecognised keys.")
+    }
+    print("   Restart Strongbox to apply all changes.")
+}
+
+func listPrefs() throws {
+    guard let (plistURL, groupID) = locatePlist() else {
+        throw StrongboxPrefsError.plistNotFound
+    }
+
+    let all = try readPlist(from: plistURL)
+
+    print("Strongbox macOS Preferences  [\(groupID)]")
+    print(String(repeating: "─", count: 60))
+
+    let sorted = exportableKeys.sorted()
+    for key in sorted {
+        if let value = all[key] {
+            print("  \(key) = \(value)")
+        }
+    }
+    print(String(repeating: "─", count: 60))
+}
+
+// MARK: – Errors
+
+enum StrongboxPrefsError: LocalizedError {
+    case plistNotFound, invalidPlist, invalidJSON, missingArgument(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .plistNotFound:
+            return """
+            Could not find the Strongbox preferences plist.
+            Searched in:
+            \(knownGroupIDs.map { "  ~/Library/Group Containers/\($0)/Library/Preferences/\($0).plist" }.joined(separator: "\n"))
+            Make sure Strongbox has been run at least once.
+            """
+        case .invalidPlist:
+            return "The plist file could not be parsed."
+        case .invalidJSON:
+            return "The input file is not valid JSON."
+        case .missingArgument(let msg):
+            return msg
+        }
+    }
+}
+
+// MARK: – Entry Point
+
+func printUsage() {
+    print("""
+    strongbox-prefs – Export / Import Strongbox macOS Preferences
+
+    USAGE:
+      strongbox-prefs export [output.json]   Export user settings to JSON
+      strongbox-prefs import <input.json>    Import user settings from JSON
+      strongbox-prefs list                   Show current exportable settings
+
+    NOTES:
+      • Only user-configurable settings are included (no license data,
+        no biometric cache, no CloudKit tokens, no database list).
+      • After importing, restart Strongbox for all settings to take effect.
+      • Binary plist values (Data, Date) are preserved through a typed JSON
+        wrapper so the round-trip is lossless.
+    """)
+}
+
+let args = CommandLine.arguments.dropFirst()
+
+do {
+    switch args.first {
+    case "export":
+        try exportPrefs(to: args.dropFirst().first)
+    case "import":
+        guard let path = args.dropFirst().first else {
+            throw StrongboxPrefsError.missingArgument("Usage: strongbox-prefs import <input.json>")
+        }
+        try importPrefs(from: path)
+    case "list":
+        try listPrefs()
+    default:
+        printUsage()
+        if args.first != nil && args.first != "--help" && args.first != "-h" {
+            exit(1)
+        }
+    }
+} catch {
+    fputs("🔴 Error: \(error.localizedDescription)\n", stderr)
+    exit(1)
+}

--- a/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
+++ b/tools/strongbox-prefs-tool/Sources/StrongboxPrefs/main.swift
@@ -335,9 +335,41 @@ func exportPrefs(to outputPath: String?) throws {
     print("   → \(destination.path)")
 }
 
-func importPrefs(from inputPath: String) throws {
+/// Writes a timestamped backup of all currently exported settings to the current working directory.
+/// Returns the URL of the written backup file.
+@discardableResult
+func backupPrefs(sources: [PlistSource]) throws -> URL {
+    var snapshot: [String: Any] = [:]
+
+    for source in sources {
+        let all = try readPlist(from: source.url)
+        for key in source.exportableKeys {
+            if let value = all[key] {
+                snapshot[key] = plistValueToJSON(value)
+            }
+        }
+    }
+
+    let json = try JSONSerialization.data(withJSONObject: snapshot, options: [.prettyPrinted, .sortedKeys])
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate, .withTime, .withColonSeparatorInTime]
+    let timestamp = formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+    let name = "strongbox-prefs-backup-\(timestamp).json"
+    let dest = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appending(path: name, directoryHint: .notDirectory)
+
+    try json.write(to: dest, options: .atomic)
+    return dest
+}
+
+func importPrefs(from inputPath: String, merge: Bool) throws {
     let sources = resolveSources()
     guard !sources.isEmpty else { throw StrongboxPrefsError.plistNotFound }
+
+    // 1. Backup current state before any changes
+    let backupURL = try backupPrefs(sources: sources)
+    print("📦 Backup written to: \(backupURL.lastPathComponent)")
 
     let jsonData = try Data(contentsOf: URL(fileURLWithPath: inputPath))
     guard let jsonDict = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
@@ -352,8 +384,21 @@ func importPrefs(from inputPath: String) throws {
         }
     }
 
-    // Group the incoming key/value pairs by their target plist
+    // 2. In replace mode (default): strip all exportable keys from each plist first,
+    //    producing a clean baseline before writing the incoming values.
+    //    In --merge mode: keep existing values and only overwrite keys present in the file.
     var plistUpdates: [URL: [String: Any]] = [:]
+    for source in sources {
+        var dict = try readPlist(from: source.url)
+        if !merge {
+            for key in source.exportableKeys {
+                dict.removeValue(forKey: key)
+            }
+        }
+        plistUpdates[source.url] = dict
+    }
+
+    // 3. Write incoming key/value pairs into the (possibly stripped) plists
     var importedCount = 0
     var skippedCount = 0
 
@@ -363,19 +408,16 @@ func importPrefs(from inputPath: String) throws {
             skippedCount += 1
             continue
         }
-        if plistUpdates[source.url] == nil {
-            plistUpdates[source.url] = try readPlist(from: source.url)
-        }
         plistUpdates[source.url]![key] = jsonValueToPlist(jsonValue)
         importedCount += 1
     }
 
-    // Write each modified plist back
+    // 4. Write each modified plist back
     for (url, dict) in plistUpdates {
         try writePlist(dict, to: url)
     }
 
-    // Touch each source domain so cfprefsd picks up the changes immediately
+    // 5. Touch each source domain so cfprefsd picks up the changes immediately
     for source in sources {
         let task = Process()
         task.launchPath = "/usr/bin/defaults"
@@ -386,7 +428,8 @@ func importPrefs(from inputPath: String) throws {
         task.waitUntilExit()
     }
 
-    print("✅ Imported \(importedCount) settings")
+    let mode = merge ? "merged" : "replaced (clean baseline)"
+    print("✅ Imported \(importedCount) settings [\(mode)]")
     if skippedCount > 0 { print("   ⚠️  Skipped \(skippedCount) unrecognised keys.") }
     print("   Restart Strongbox to apply all changes.")
 }
@@ -444,9 +487,17 @@ func printUsage() {
     strongbox-prefs – Export / Import Strongbox macOS Preferences
 
     USAGE:
-      strongbox-prefs export [output.json]   Export all user settings to JSON
-      strongbox-prefs import <input.json>    Import user settings from JSON
-      strongbox-prefs list                   Show current exportable settings
+      strongbox-prefs export [output.json]          Export all user settings to JSON
+      strongbox-prefs import <input.json> [--merge] Import user settings from JSON
+      strongbox-prefs list                          Show current exportable settings
+
+    IMPORT MODES:
+      Default (replace):  All exportable settings are wiped first (clean baseline),
+                          then the values from the file are written.
+      --merge:            Existing settings are kept; only keys present in the file
+                          are overwritten.
+      In both modes a timestamped backup is written to the current directory before
+      any changes are made.
 
     NOTES:
       • Settings from both the App Group plist and the standard sandboxed-app
@@ -466,10 +517,12 @@ do {
     case "export":
         try exportPrefs(to: args.dropFirst().first)
     case "import":
-        guard let path = args.dropFirst().first else {
-            throw StrongboxPrefsError.missingArgument("Usage: strongbox-prefs import <input.json>")
+        let importArgs = args.dropFirst()
+        guard let path = importArgs.first(where: { !$0.hasPrefix("--") }) else {
+            throw StrongboxPrefsError.missingArgument("Usage: strongbox-prefs import <input.json> [--merge]")
         }
-        try importPrefs(from: path)
+        let merge = importArgs.contains("--merge")
+        try importPrefs(from: path, merge: merge)
     case "list":
         try listPrefs()
     default:


### PR DESCRIPTION
## Summary

This PR adds `strongbox-prefs-tool`, a standalone macOS command-line utility that exports all user-configurable Strongbox preferences to a JSON file and imports them back. It addresses the need described in issue #260 for the macOS platform.

No existing Strongbox code is modified. The tool lives entirely in `tools/strongbox-prefs-tool/` and is built separately via Swift Package Manager.

---

## Problem

When migrating to a new Mac or reinstalling Strongbox, all preferences must be reconfigured manually. There is no built-in way to transfer the ~87 configurable settings that Strongbox stores across two separate plist files.

---

## Solution

A lightweight Swift CLI tool that reads and writes Strongbox preferences directly from/to both plist files, producing a single portable JSON file.

### Installation

```bash
cd tools/strongbox-prefs-tool
swift build -c release
# Optional: copy to PATH
cp .build/release/strongbox-prefs /usr/local/bin/strongbox-prefs
```

### Usage

```
strongbox-prefs export [output.json]          Export all user settings to JSON
strongbox-prefs import <input.json>           Import settings (replace mode)
strongbox-prefs import <input.json> --merge   Import settings (merge mode)
strongbox-prefs list                          Show current exportable settings
```

### Typical workflow

```bash
# On the old Mac:
strongbox-prefs export ~/Desktop/strongbox-settings.json

# Transfer the file (AirDrop, iCloud Drive, USB, …)

# On the new Mac (after launching Strongbox at least once):
strongbox-prefs import ~/Desktop/strongbox-settings.json
# → Restart Strongbox to apply all changes
```

---

## Technical details

### Two plist sources

Strongbox stores settings in two separate locations that this tool handles transparently:

| Source | Path | Content |
|--------|------|---------|
| App Group plist | `~/Library/Group Containers/group.strongbox.mac.mcguill/…/group.strongbox.mac.mcguill.plist` | ~84 user-configurable settings via `Settings.sharedInstance` |
| Standard (sandboxed-app) plist | `~/Library/Containers/com.markmcguill.strongbox/…/com.markmcguill.strongbox.plist` | 3 keyboard shortcut keys via `MASShortcutBinder` |

Both known App Group IDs (dev/direct and App Store build) are probed automatically.

### Import modes

**Replace (default):** All exportable keys are stripped from both plists first, establishing a clean baseline. Only values present in the import file are written. Stale settings from a previous configuration cannot survive.

**`--merge`:** Existing settings are preserved; only keys present in the import file are overwritten. Useful for partial transfers or combining settings from two machines.

### Automatic backup

Every `import` run writes a timestamped JSON snapshot of the current settings to the working directory before making any changes:

```
strongbox-prefs-backup-2026-03-24T15-34-02.json
```

The backup file uses the same format as a regular export and can be re-imported directly.

### What is exported (~87 keys)

- Auto-lock timeouts and App Lock mode/delay
- Clipboard handling (clear timeout, handoff, conceal from monitors)
- Backup and sync options (rolling backups, atomic SFTP, Wi-Fi Sync on/off)
- UI preferences (appearance, markdown notes, colorblind palette, window behaviour, system tray)
- TOTP display (easy-read separator, hide countdown, add OTPAuth URL)
- Password generator configuration
- FavIcon download options
- AutoFill new record settings
- SSH Agent configuration
- Browser AutoFill proxy
- Duplicate item behaviour
- Access/restriction flags (read-only mode, disable export/print/copy-to)
- Enterprise organisation name
- Global keyboard shortcuts (via MASShortcutBinder)

### What is intentionally excluded

Security-sensitive and device-specific values are never exported:

- License / Pro status and entitlement state
- Biometric cache (`lastKnownGoodBiometricsDatabaseState`)
- App Lock PIN (stored in SecretStore, not plist)
- CloudKit zone tokens and subscription state
- Database list and per-database metadata
- Install date, launch counters, onboarding flags
- Wi-Fi Sync service name (device-specific)
- Keychain references of any kind

### Binary plist values

`Data` and `Date` values, which JSON cannot represent natively, are round-tripped losslessly through a typed wrapper:

```json
{ "__type": "data", "value": "<base64>" }
{ "__type": "date", "value": "2026-03-24T15:34:02Z" }
```

### cfprefsd cache flush

After writing the plists the tool calls `defaults read <domain>` for each modified domain so `cfprefsd` picks up the changes immediately without requiring a logout.

---

## Files changed

```
tools/strongbox-prefs-tool/
├── Package.swift                          SPM manifest (no external dependencies)
├── README.md                              Build and usage documentation
└── Sources/StrongboxPrefs/main.swift      Complete implementation (~535 lines)
```

No existing source files are modified.

---

## Commits

- `90644f23` Add strongbox-prefs-tool: macOS CLI utility for exporting and importing Strongbox preferences
- `150675fc` Fix strongbox-prefs-tool: correct wrong key and add 10 missing exportable settings
- `b79c167b` Fix strongbox-prefs-tool: handle keyboard shortcuts stored in separate plist
- `91631290` strongbox-prefs-tool: backup before import, clean-baseline replace mode

---

## Testing checklist

- [ ] `swift build -c release` completes without errors on macOS 13+
- [ ] `export` produces valid JSON with the expected keys
- [ ] `import` (replace mode) correctly removes stale keys and writes imported values
- [ ] `import --merge` preserves existing keys not present in the import file
- [ ] Backup file is created before every import run
- [ ] Keyboard shortcuts (`GlobalShowStrongboxHotKey-New`, `LaunchQuickSearchShortcut`, `PasswordGeneratorShortcut`) are correctly exported and imported
- [ ] Both App Group IDs (dev and App Store) are resolved correctly
- [ ] Strongbox reflects imported settings after restart
- [ ] Export on Mac A → import on Mac B transfers all ~87 keys correctly
- [ ] `list` command shows current values for all exportable keys
- [ ] Binary plist values (`Data`, `Date`) round-trip without loss